### PR TITLE
feat(cli): add xtool and xtool-gui short aliases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,6 +215,9 @@ conflicts = [
 [project.scripts]
 xraylabtool = "xraylabtool.interfaces.cli:main"
 xraylabtool-gui = "xraylabtool.gui.__main__:main"
+# Short aliases
+xtool = "xraylabtool.interfaces.cli:main"
+xtool-gui = "xraylabtool.gui.__main__:main"
 
 [tool.setuptools]
 zip-safe = false


### PR DESCRIPTION
Add short console-script aliases so the CLI/GUI can be invoked as `xtool` / `xtool-gui` in addition to the existing `xraylabtool` / `xraylabtool-gui`.

```toml
[project.scripts]
xraylabtool     = "xraylabtool.interfaces.cli:main"
xraylabtool-gui = "xraylabtool.gui.__main__:main"
xtool           = "xraylabtool.interfaces.cli:main"      # new alias
xtool-gui       = "xraylabtool.gui.__main__:main"        # new alias
```

Verified after `pip install -e .`: `xtool --version` → `XRayLabTool 0.4.4`, `xtool calc SiO2 -e 10.0 -d 2.2` runs; both entry points resolve. (Console scripts materialize on (re)install.)

Not included (YAGNI): shell-completion registration for the alias names and README mentions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)